### PR TITLE
Handle missing dependency in pre-download script

### DIFF
--- a/pre-download.py
+++ b/pre-download.py
@@ -1,4 +1,25 @@
-# A file to make it easy to pre-download the Sentence Transformer model in Coursera Labs. It doesn't do anything other than
-# to run the sentence transformer so that it can pre-download the model in the lab
-from sentence_transformers import SentenceTransformer
-SentenceTransformer('all-MiniLM-L6-v2') # Model to create embeddings
+"""Helper script to pre-download Sentence Transformer models.
+
+This file exists so the SentenceTransformer model used in the labs can be
+downloaded ahead of time. Previously the import was executed at the module
+level, which caused a ``ModuleNotFoundError`` in environments where
+``sentence_transformers`` hadn't been installed yet.  By moving the import
+inside a function we avoid that failure and provide a clearer error message.
+"""
+
+
+def download_model() -> None:
+    """Download the embedding model if the dependency is available."""
+    try:
+        from sentence_transformers import SentenceTransformer
+    except ModuleNotFoundError as exc:  # pragma: no cover - defensive
+        raise SystemExit(
+            "sentence-transformers is not installed. Please install the "
+            "required dependencies before running this script."
+        ) from exc
+
+    SentenceTransformer("all-MiniLM-L6-v2")  # Model to create embeddings
+
+
+if __name__ == "__main__":  # pragma: no cover - script guard
+    download_model()


### PR DESCRIPTION
## Summary
- avoid ModuleNotFoundError by importing sentence_transformers inside a function
- provide helpful message when dependency is missing

## Testing
- `python -m py_compile pre-download.py`
- `python pre-download.py` (expected failure when library not installed)


------
https://chatgpt.com/codex/tasks/task_e_68981097ec348329b8106cdc1eac7fb9